### PR TITLE
fix: correct link for header image copyright

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -36,7 +36,7 @@
             <img src="/assets/images/sponsors/freshworks.png" alt="Freshworks" style="display:block;margin:0;padding:0;width:150px;"/>
           </a>
         </p>
-        <p>Header image by <a href="https://www.flickr.com/photos/basq/8602547855/in/album-72157604005131955/">Jens Mayer</a> used under CC BY / Modified / Thanks!</p>
+        <p>Header image by <a href="https://www.flickr.com/photos/basq/32195704870/">Jens Mayer</a> used under CC BY / Modified / Thanks!</p>
 
       </footer>
     </section>


### PR DESCRIPTION
fixes https://github.com/rughh/2019-website/issues/1